### PR TITLE
[feat] 마이페이지 CRUD: 마이페이지 조회/수정/삭제 + 역할 선택 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+src/**/application-prod.yml

--- a/build.gradle
+++ b/build.gradle
@@ -26,11 +26,23 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // 구글
+    implementation 'com.google.code.gson:gson:2.10.1'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+    runtimeOnly   'io.jsonwebtoken:jjwt-impl:0.12.5'
+    runtimeOnly   'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/likelion/neezybackend/common/error/ErrorCode.java
+++ b/src/main/java/com/likelion/neezybackend/common/error/ErrorCode.java
@@ -1,0 +1,28 @@
+package com.likelion.neezybackend.common.error;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter // getter 메소드 자동 생성 lombok 어노테이션
+@AllArgsConstructor(access = AccessLevel.PRIVATE) // 모든 필드를 파라미터로 받는 생성자 자동 생성 어노테이션
+public enum ErrorCode {
+
+    // 401 UNAUTHORIZED (인증 실패/미인증)
+    NO_AUTHORIZATION_EXCEPTION(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.", "UNAUTHORIZED_401"),
+
+    //404 NOT FOUND (찾을 수 없음)
+    MEMBER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "해당 사용자가 없습니다. memberId = ", "NOT_FOUND_404"),
+
+    // 500 INTERNAL SERVER ERROR (내부 서버 에러)
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러가 발생했습니다", "INTERNAL_SERVER_ERROR_500");
+
+    private final HttpStatus httpStatus;    // HTTP 상태 코드 ex) 404, 500 -> 포스트맨에서 뜨는 상태 코드
+    private final String message;           // 에러 메세지
+    private final String code;              // 에러 코드
+
+    public int getHttpStatusCode() {        // HTTP 상태 코드에서 404와 같은 숫자 값만 반환해 주기 위한 메소드
+        return httpStatus.value();
+    }
+}

--- a/src/main/java/com/likelion/neezybackend/common/error/SuccessCode.java
+++ b/src/main/java/com/likelion/neezybackend/common/error/SuccessCode.java
@@ -1,0 +1,31 @@
+package com.likelion.neezybackend.common.error;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter // getter 메소드 자동 생성 lombok 어노테이션
+@AllArgsConstructor(access = AccessLevel.PRIVATE) // 모든 필드를 파라미터로 받는 생성자 자동 생성 어노테이션
+public enum SuccessCode {
+
+    /**
+     * 200 OK (성공)
+     */
+    GET_SUCCESS(HttpStatus.OK, "성공적으로 조회했습니다."),
+    MEMBER_UPDATE_SUCCESS(HttpStatus.OK, "사용자가 성공적으로 수정되었습니다."),
+    MEMBER_DELETE_SUCCESS(HttpStatus.OK, "사용자가 성공적으로 삭제되었습니다."),
+
+    /**
+     * 201 CREATED (생성 성공)
+     */
+    MEMBER_SAVE_SUCCESS(HttpStatus.CREATED, "사용자가 성공적으로 생성되었습니다.");
+
+    private final HttpStatus httpStatus;   // HTTP 상태 코드 ex) 200, 201
+    private final String message;          // 응답 메세지
+
+    public int getHttpStatusCode() {       // HTTP 상태 코드에서 404와 같은 숫자 값만 반환해 주기 위한 메소드
+        return httpStatus.value();
+    }
+}
+

--- a/src/main/java/com/likelion/neezybackend/common/exception/BusinessException.java
+++ b/src/main/java/com/likelion/neezybackend/common/exception/BusinessException.java
@@ -1,0 +1,18 @@
+package com.likelion.neezybackend.common.exception;
+
+import com.likelion.neezybackend.common.error.ErrorCode;
+import lombok.Getter;
+
+@Getter // getter 메소드 자동 생성 lombok 어노테이션
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;   // 에러 코드 ex) NOT_FOUND
+    private final String customMessage;  // 사용자 정의 예외 메시지(커스텀)
+
+    // 생성자
+    public BusinessException(ErrorCode errorCode, String customMessage) {
+        super(customMessage);    // RuntimeException의 생성자에 메시지 전달
+        this.errorCode = errorCode;
+        this.customMessage = customMessage;
+    }
+}

--- a/src/main/java/com/likelion/neezybackend/common/template/ApiResTemplate.java
+++ b/src/main/java/com/likelion/neezybackend/common/template/ApiResTemplate.java
@@ -1,0 +1,33 @@
+package com.likelion.neezybackend.common.template;
+
+import com.likelion.neezybackend.common.error.ErrorCode;
+import com.likelion.neezybackend.common.error.SuccessCode;
+import lombok.*;
+
+@Getter // getter 메소드 자동 생성 lombok 어노테이션
+@AllArgsConstructor(access = AccessLevel.PRIVATE) // 모든 필드 값을 매개변수로 받는 생성자 자동 생성
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE) // final 붙은 필드만 매개변수로 받는 생성자 자동 생성
+@Builder // 빌더 패턴
+public class ApiResTemplate<T> {
+
+    private final int code;       // 응답 코드 (200, 404 등)
+    private final String message; // 응답 메시지
+    private T data;               // 응답 데이터 (제네릭 형식으로 다양한 타입 수용 가능)
+
+    // 데이터 없는 성공 응답
+    public static ApiResTemplate successWithNoContent(SuccessCode successCode) {
+        return new ApiResTemplate<>(successCode.getHttpStatusCode(), successCode.getMessage());
+    }
+
+    // 데이터 포함한 성공 응답
+    public static <T> ApiResTemplate<T> successResponse(SuccessCode successCode, T data) {
+        return new ApiResTemplate<>(successCode.getHttpStatusCode(), successCode.getMessage(), data);
+    }
+
+    // 에러 응답 (커스텀 메시지 포함)
+    public static ApiResTemplate errorResponse(ErrorCode errorCode, String customMessage) {
+        return new ApiResTemplate<>(errorCode.getHttpStatusCode(), customMessage);
+    }
+
+}
+

--- a/src/main/java/com/likelion/neezybackend/global/config/SecurityConfig.java
+++ b/src/main/java/com/likelion/neezybackend/global/config/SecurityConfig.java
@@ -1,0 +1,45 @@
+package com.likelion.neezybackend.global.config;
+
+import com.likelion.neezybackend.global.jwt.JwtAuthorizationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthorizationFilter jwtAuthorizationFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/login/oauth2/**").permitAll()
+                        .requestMatchers("/members/**", "/posts/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                // 한 번만 등록
+                .addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/src/main/java/com/likelion/neezybackend/global/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/likelion/neezybackend/global/jwt/JwtAuthorizationFilter.java
@@ -1,0 +1,45 @@
+package com.likelion.neezybackend.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends GenericFilterBean {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // 모든 요청이 들어올 때 필터가 가로채 인증 로직 실행
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws
+            IOException, ServletException {
+        String token = resolveToken((HttpServletRequest) request); // 요청에서 토큰 resolve(추출)
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {   // 토큰이 유효한지 확인
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);  // 유효하다면 토큰으로부터 인증 정보 가져옴
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            // SecurityContext에 인증 정보 저장 -> 이후 요청 처리에서 인증된 사용자 정보에 접근할 수 있음
+        }
+        chain.doFilter(request, response); // 필터 체인의 다음 필터로 요청 넘기기
+    }
+
+    // 요청에서 토큰 추출 메소드
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");    // 헤더에서 Authorization 값 꺼내기
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);    // "Bearer " 부분을 잘라내고 토큰만 리턴
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/likelion/neezybackend/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/likelion/neezybackend/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,124 @@
+package com.likelion.neezybackend.global.jwt;
+
+import com.likelion.neezybackend.common.error.ErrorCode;
+import com.likelion.neezybackend.common.exception.BusinessException;
+import com.likelion.neezybackend.member.domain.Member;
+import com.likelion.neezybackend.member.domain.repository.MemberRepository;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.List;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+@Slf4j  // 로그 작성
+@Component  // spring bean에 등록
+public class JwtTokenProvider {
+
+    private static final String AUTHORITIES_KEY = "auth"; // 권한 키 상수 추가
+    private final MemberRepository memberRepository;
+
+    @Value("${token.expire.time}") // factory annotation 임포트
+    private String tokenExpireTime; // 토큰 만료 시간
+
+    @Value("${jwt.secret}")
+    private String secret;  // 비밀키
+
+    private SecretKey key;  // 객체 key
+
+    public JwtTokenProvider(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @PostConstruct  // Bean이 초기화 된 후에 실행
+    public void init() {    // 필터 객체를 초기화하고 서비스에 추가하기 위한 메소드 init
+        byte[] keyBytes = Decoders.BASE64.decode(secret);   // 시크릿 키 디코딩 후
+        this.key = Keys.hmacShaKeyFor(keyBytes); // 키 암호화
+    }
+
+    // 토큰 생성
+    public String generateToken(Member member) {
+        // 만료 시간 설정 util로 임포트
+        Date now = new Date();
+        Date expireDate = new Date(now.getTime() + Long.parseLong(tokenExpireTime));
+
+        return Jwts.builder()
+                .subject(member.getMemberId().toString())   // 토큰 주체를 id로 설정
+                .claim(AUTHORITIES_KEY, member.getRole().toString()) // 추가된 권한 Claim
+                .issuedAt(now)  // 발행 시간
+                .expiration(expireDate) // 만료 시간
+                .signWith(key, Jwts.SIG.HS256)  // ㅏ토큰 암호화
+                .compact(); // 압축, 서명 후 토큰 생성
+    }
+
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token);  // 토큰 파싱, 검증
+            return true;    // 검증 완료 -> 유효한 토큰
+            // 검증 실패 시 반환하는 예외에 따라 다르게 실행
+        } catch (UnsupportedJwtException | MalformedJwtException e) {
+            throw new BusinessException(ErrorCode.NO_AUTHORIZATION_EXCEPTION, "JWT 가 유효하지 않습니다.");
+        } catch (SignatureException e) {
+            throw new BusinessException(ErrorCode.NO_AUTHORIZATION_EXCEPTION, "JWT 서명 검증에 실패했습니다.");
+        } catch (ExpiredJwtException e) {
+            throw new BusinessException(ErrorCode.NO_AUTHORIZATION_EXCEPTION, "JWT 가 만료되었습니다.");
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.NO_AUTHORIZATION_EXCEPTION, "JWT 가 null 이거나 비어있거나 공백만 있습니다.");
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.NO_AUTHORIZATION_EXCEPTION, "JWT 검증에 실패했습니다.");
+        }
+    }
+
+    // 인증 객체 반환 core 로 임포트
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+
+        String authority = claims.get(AUTHORITIES_KEY, String.class);
+        if(authority == null) {
+            throw new BusinessException(ErrorCode.NO_AUTHORIZATION_EXCEPTION, "권한 정보가 없는 토큰입니다.");
+        }
+
+        List<GrantedAuthority> authorities = Arrays.stream(authority.split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        // memberId, 공백, authorities 반환
+        return new UsernamePasswordAuthenticationToken(claims.getSubject(), "", authorities);
+    }
+
+    // Claims 파싱
+    private Claims parseClaims(String accessToken) {
+        try{
+            JwtParser parser = Jwts.parser()
+                    .verifyWith(key)
+                    .build();
+
+            return parser.parseSignedClaims(accessToken).getPayload();
+        }catch (ExpiredJwtException e){
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/com/likelion/neezybackend/member/api/MemberController.java
+++ b/src/main/java/com/likelion/neezybackend/member/api/MemberController.java
@@ -1,0 +1,49 @@
+package com.likelion.neezybackend.member.api;
+
+import com.likelion.neezybackend.member.api.dto.request.ChooseRoleRequestDto;
+import com.likelion.neezybackend.member.api.dto.request.MemberUpdateRequestDto;
+import com.likelion.neezybackend.member.api.dto.response.MemberInfoResponseDto;
+import com.likelion.neezybackend.member.application.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class MemberController {
+    private final MemberService memberService;
+
+
+    // 회원 id를 통해 특정 사용자 조회
+    @GetMapping("/{memberId}")
+    public ResponseEntity<MemberInfoResponseDto> memberFindOne(@PathVariable("memberId") Long memberId) {
+        MemberInfoResponseDto memberInfoResponseDto = memberService.memberFindOne(memberId);
+        return new ResponseEntity<>(memberInfoResponseDto, HttpStatus.OK);
+    }
+
+    // 회원 id를 통한 사용자 수정
+    @PatchMapping("/{memberId}")
+    public ResponseEntity<String> memberUpdate(@PathVariable("memberId") Long memberId,
+                                               @RequestBody MemberUpdateRequestDto memberUpdateRequestDto) {
+        memberService.memberUpdate(memberId, memberUpdateRequestDto);
+        return new ResponseEntity<>("사용자 수정", HttpStatus.OK);
+    }
+
+    // 회원 id를 통한 사용자 삭제
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity<String> memberDelete(@PathVariable("memberId") Long memberId) {
+        memberService.memberDelete(memberId);
+        return new ResponseEntity<>("사용자 삭제", HttpStatus.OK);
+    }
+
+    // 역할 선택 
+    @PatchMapping("/api/members/{memberId}/role")
+    public ResponseEntity<String> chooseRole(@PathVariable Long memberId,
+                                             @RequestBody ChooseRoleRequestDto dto) {
+        memberService.memberChooseRole(memberId, dto);
+        return new ResponseEntity<>("역할 선택 완료", HttpStatus.OK);
+    }
+}
+

--- a/src/main/java/com/likelion/neezybackend/member/api/dto/request/ChooseRoleRequestDto.java
+++ b/src/main/java/com/likelion/neezybackend/member/api/dto/request/ChooseRoleRequestDto.java
@@ -1,0 +1,6 @@
+package com.likelion.neezybackend.member.api.dto.request;
+
+import com.likelion.neezybackend.member.domain.Role;
+
+public record ChooseRoleRequestDto(Role role) {
+}

--- a/src/main/java/com/likelion/neezybackend/member/api/dto/request/MemberUpdateRequestDto.java
+++ b/src/main/java/com/likelion/neezybackend/member/api/dto/request/MemberUpdateRequestDto.java
@@ -1,0 +1,15 @@
+package com.likelion.neezybackend.member.api.dto.request;
+
+import com.likelion.neezybackend.member.domain.Gender;
+import com.likelion.neezybackend.member.domain.Role;
+import jakarta.validation.constraints.*;
+
+public record MemberUpdateRequestDto(
+        @Size(min = 1, max = 80) String name,
+        @Email @Size(max = 255) String email,
+        @Min(0) @Max(120) Integer age,
+        Gender gender,
+        @Size(max = 512) String pictureUrl,
+        Role role
+) {
+}

--- a/src/main/java/com/likelion/neezybackend/member/api/dto/response/MemberInfoResponseDto.java
+++ b/src/main/java/com/likelion/neezybackend/member/api/dto/response/MemberInfoResponseDto.java
@@ -1,0 +1,27 @@
+package com.likelion.neezybackend.member.api.dto.response;
+
+import com.likelion.neezybackend.member.domain.Member;
+import lombok.Builder;
+
+@Builder
+public record MemberInfoResponseDto(
+        Long id,
+        String name,
+        String email,
+        Integer age,       // null 가능
+        String gender,     // enum -> 문자열로 노출(프론트 호환성↑)
+        String pictureUrl,
+        String role        // enum -> 문자열
+) {
+    public static MemberInfoResponseDto from(Member member) {
+        return MemberInfoResponseDto.builder()
+                .id(member.getMemberId())
+                .name(member.getName())
+                .email(member.getEmail())
+                .age(member.getAge())
+                .gender(member.getGender() != null ? member.getGender().name() : "UNKNOWN")
+                .pictureUrl(member.getPictureUrl())
+                .role(member.getRole() != null ? member.getRole().name() : null)
+                .build();
+    }
+}

--- a/src/main/java/com/likelion/neezybackend/member/api/dto/response/MemberListResponseDto.java
+++ b/src/main/java/com/likelion/neezybackend/member/api/dto/response/MemberListResponseDto.java
@@ -1,0 +1,18 @@
+package com.likelion.neezybackend.member.api.dto.response;
+
+import com.likelion.neezybackend.member.domain.Member;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record MemberListResponseDto(
+        List<MemberInfoResponseDto> members
+) {
+    // 엔티티 리스트 -> DTO 리스트로 바로 변환
+    public static MemberListResponseDto from(List<MemberInfoResponseDto> members) {
+        return MemberListResponseDto.builder()
+                .members(members)
+                .build();
+    }
+}

--- a/src/main/java/com/likelion/neezybackend/member/application/MemberService.java
+++ b/src/main/java/com/likelion/neezybackend/member/application/MemberService.java
@@ -1,0 +1,63 @@
+package com.likelion.neezybackend.member.application;
+
+import com.likelion.neezybackend.member.api.dto.request.ChooseRoleRequestDto;
+import com.likelion.neezybackend.member.api.dto.request.MemberUpdateRequestDto;
+import com.likelion.neezybackend.member.api.dto.response.MemberInfoResponseDto;
+import com.likelion.neezybackend.member.domain.Member;
+import com.likelion.neezybackend.member.domain.Role;
+import com.likelion.neezybackend.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    // 내 정보 조회
+    public MemberInfoResponseDto memberFindOne(Long memberId) {
+        Member member = memberRepository
+                .findById(memberId)
+                .orElseThrow(IllegalArgumentException::new);
+        return MemberInfoResponseDto.from(member);
+    }
+
+    // 사용자 정보 수정
+    @Transactional
+    public void memberUpdate(Long memberId,
+                             MemberUpdateRequestDto memberUpdateRequestDto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(IllegalArgumentException::new);
+
+        member.update(memberUpdateRequestDto);
+    }
+
+    // 사용자 정보 삭제
+    @Transactional
+    public void memberDelete(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(IllegalArgumentException::new);
+
+        memberRepository.delete(member);
+    }
+
+    // 온보딩: PENDING일 때 1회만 역할 선택
+    @Transactional
+    public void memberChooseRole(Long memberId, ChooseRoleRequestDto dto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(IllegalArgumentException::new);
+
+        if (dto.role() == null || dto.role() == Role.PENDING) {
+            throw new IllegalArgumentException("invalid role");
+        }
+        if (member.getRole() != Role.PENDING) {
+            throw new IllegalStateException("role already chosen");
+        }
+
+        member.chooseRole(dto.role()); // 엔티티 메서드
+    }
+}

--- a/src/main/java/com/likelion/neezybackend/member/domain/Gender.java
+++ b/src/main/java/com/likelion/neezybackend/member/domain/Gender.java
@@ -1,0 +1,7 @@
+package com.likelion.neezybackend.member.domain;
+
+public enum Gender {
+    MALE,
+    FEMALE,
+    UNKNOWN
+}

--- a/src/main/java/com/likelion/neezybackend/member/domain/Member.java
+++ b/src/main/java/com/likelion/neezybackend/member/domain/Member.java
@@ -1,0 +1,56 @@
+package com.likelion.neezybackend.member.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long memberId;
+
+    // === 소셜 로그인 식별자(반드시 필요) ===
+    @Column(name = "provider", nullable = false, length = 20)
+    private String provider;          // GOOGLE | KAKAO
+
+    @Column(name = "provider_id", nullable = false, length = 100)
+    private String providerId;          // Google sub, Kakao id
+
+    @Column(name = "member_email")
+    private String email;
+
+
+    @Column(name = "member_name")
+    private String name;
+
+    @Column(name = "member_picture_url", length = 512)
+    private String pictureUrl;
+
+    // 역할: 창업자/사용자/미선택(기본)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "member_role", nullable = false)
+    private Role role = Role.PENDING;  // 기본은 '선택 전'
+
+    // 사용자가 화면에서 역할 고르면 호출
+    public void chooseRole(Role role) {  // 아주 단순
+        this.role = role;
+    }
+
+    @Builder
+    public Member(String provider, String providerId,
+                  String email, String name, String pictureUrl, Role role) {
+        this.provider = provider;
+        this.providerId = providerId;
+        this.email = email;
+        this.name = name;
+        this.pictureUrl = pictureUrl;
+        this.role = (role != null ? role : Role.PENDING);
+    }
+}

--- a/src/main/java/com/likelion/neezybackend/member/domain/Member.java
+++ b/src/main/java/com/likelion/neezybackend/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.likelion.neezybackend.member.domain;
 
+import com.likelion.neezybackend.member.api.dto.request.MemberUpdateRequestDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -38,18 +39,49 @@ public class Member {
     @Column(name = "member_role", nullable = false)
     private Role role = Role.PENDING;  // 기본은 '선택 전'
 
+    /* === 새 필드 === */
+    @Column(name = "member_age")
+    private Integer age; // nullable: 소셜에서 안 주면 마이페이지에서 입력
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "member_gender", length = 16)
+    private Gender gender = Gender.UNKNOWN;
+
     // 사용자가 화면에서 역할 고르면 호출
     public void chooseRole(Role role) {  // 아주 단순
         this.role = role;
     }
 
+    public void update(MemberUpdateRequestDto dto) {
+        if (dto.name() != null && !dto.name().isBlank()) {
+            this.name = dto.name();
+        }
+        if (dto.email() != null && !dto.email().isBlank()) {
+            this.email = dto.email();
+        }
+        if (dto.age() != null) {
+            this.age = dto.age();
+        }
+        if (dto.gender() != null) {
+            this.gender = dto.gender();
+        }
+        if (dto.pictureUrl() != null && !dto.pictureUrl().isBlank()) {
+            this.pictureUrl = dto.pictureUrl();
+        }
+        if (dto.role() != null) {
+            this.role = dto.role();
+        }
+    }
+
     @Builder
     public Member(String provider, String providerId,
-                  String email, String name, String pictureUrl, Role role) {
+                  String email, String name, Integer age, Gender gender, String pictureUrl, Role role) {
         this.provider = provider;
         this.providerId = providerId;
         this.email = email;
         this.name = name;
+        this.age = age;
+        this.gender = gender;
         this.pictureUrl = pictureUrl;
         this.role = (role != null ? role : Role.PENDING);
     }

--- a/src/main/java/com/likelion/neezybackend/member/domain/Role.java
+++ b/src/main/java/com/likelion/neezybackend/member/domain/Role.java
@@ -1,0 +1,7 @@
+package com.likelion.neezybackend.member.domain;
+
+public enum Role {
+    PENDING,
+    USER,
+    FOUNDER
+}

--- a/src/main/java/com/likelion/neezybackend/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/likelion/neezybackend/member/domain/repository/MemberRepository.java
@@ -1,0 +1,17 @@
+package com.likelion.neezybackend.member.domain.repository;
+
+import com.likelion.neezybackend.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+    boolean existsByEmail(String email);
+
+    // 소셜 식별자로 조회 (provider + providerId)
+    Optional<Member> findByProviderAndProviderId(String provider, String providerId);
+
+    // (선택) 존재 여부만 체크할 때 편리
+    boolean existsByProviderAndProviderId(String provider, String providerId);
+}

--- a/src/main/java/com/likelion/neezybackend/oauth/api/AuthLoginController.java
+++ b/src/main/java/com/likelion/neezybackend/oauth/api/AuthLoginController.java
@@ -12,12 +12,6 @@ import org.springframework.web.bind.annotation.*;
 public class AuthLoginController {
     private final AuthLoginService authLoginService;
 
-//    // code : 인증 서버에서 받은 authorization code
-//    // registrationId : 사용자가 로그인한 소셜 로그인의 id
-//    @GetMapping("/code/{registrationID}")
-//    public void googleLogin(@RequestParam String code, @PathVariable String registrationID){
-//        authLoginService.socialLogin(code, registrationID);
-//    }
 
     @GetMapping("/code/google")
     public Token googleCallback(@RequestParam(name = "code") String code){

--- a/src/main/java/com/likelion/neezybackend/oauth/api/AuthLoginController.java
+++ b/src/main/java/com/likelion/neezybackend/oauth/api/AuthLoginController.java
@@ -1,0 +1,37 @@
+package com.likelion.neezybackend.oauth.api;
+
+
+import com.likelion.neezybackend.oauth.api.dto.Token;
+import com.likelion.neezybackend.oauth.application.AuthLoginService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/login/oauth2")
+public class AuthLoginController {
+    private final AuthLoginService authLoginService;
+
+//    // code : 인증 서버에서 받은 authorization code
+//    // registrationId : 사용자가 로그인한 소셜 로그인의 id
+//    @GetMapping("/code/{registrationID}")
+//    public void googleLogin(@RequestParam String code, @PathVariable String registrationID){
+//        authLoginService.socialLogin(code, registrationID);
+//    }
+
+    @GetMapping("/code/google")
+    public Token googleCallback(@RequestParam(name = "code") String code){
+        String googleAccessToken = authLoginService.getGoogleAccessToken(code);
+        return loginOrSignup(googleAccessToken);
+    }
+
+    @GetMapping("/code/kakao")
+    public Token kakaoCallback(@RequestParam String code){
+        String at = authLoginService.getKakaoAccessToken(code);
+        return authLoginService.loginOrSignUpWithKakao(at);
+    }
+
+    public Token loginOrSignup(String googleAccessToken){
+        return authLoginService.loginOrSignUp(googleAccessToken);
+    }
+}

--- a/src/main/java/com/likelion/neezybackend/oauth/api/dto/KakaoUserInfo.java
+++ b/src/main/java/com/likelion/neezybackend/oauth/api/dto/KakaoUserInfo.java
@@ -1,0 +1,25 @@
+package com.likelion.neezybackend.oauth.api.dto;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class KakaoUserInfo {
+    private Long id;
+
+    @SerializedName("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Data
+    public static class KakaoAccount {
+        private String email;   // 동의 안 하면 null
+        private Profile profile;
+    }
+
+    @Data
+    public static class Profile {
+        private String nickname;
+        @SerializedName("profile_image_url")
+        private String profileImageUrl;
+    }
+}

--- a/src/main/java/com/likelion/neezybackend/oauth/api/dto/Token.java
+++ b/src/main/java/com/likelion/neezybackend/oauth/api/dto/Token.java
@@ -1,0 +1,15 @@
+package com.likelion.neezybackend.oauth.api.dto;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class Token {
+
+    @SerializedName("access_token")
+    private String accessToken;
+}

--- a/src/main/java/com/likelion/neezybackend/oauth/api/dto/UserInfo.java
+++ b/src/main/java/com/likelion/neezybackend/oauth/api/dto/UserInfo.java
@@ -1,0 +1,27 @@
+package com.likelion.neezybackend.oauth.api.dto;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+
+@Data
+public class UserInfo {
+    private String id;
+
+    private String email;
+
+    @SerializedName("verified_email")
+    private Boolean verifiedEmail;
+
+    private String name;
+
+    @SerializedName("given_name")
+    private String givenName;
+
+    @SerializedName("family_name")
+    private String familyName;
+
+    @SerializedName("picture")
+    private String pictureUrl;
+
+    private String locale;
+}

--- a/src/main/java/com/likelion/neezybackend/oauth/application/AuthLoginService.java
+++ b/src/main/java/com/likelion/neezybackend/oauth/application/AuthLoginService.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+import com.likelion.neezybackend.oauth.api.dto.KakaoUserInfo;
 
 import java.net.URI;
 import java.util.Map;
@@ -124,7 +125,7 @@ public class AuthLoginService {
     }
 
     // 액세스 토큰 -> 카카오 유저 정보
-    public com.likelion.neezybackend.oauth.api.dto.KakaoUserInfo getKakaoUserInfo(String accessToken){
+    public KakaoUserInfo getKakaoUserInfo(String accessToken){
         String url = "https://kapi.kakao.com/v2/user/me";
 
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/likelion/neezybackend/oauth/application/AuthLoginService.java
+++ b/src/main/java/com/likelion/neezybackend/oauth/application/AuthLoginService.java
@@ -1,0 +1,190 @@
+package com.likelion.neezybackend.oauth.application;
+
+import com.google.gson.Gson;
+import com.likelion.neezybackend.global.jwt.JwtTokenProvider;
+import com.likelion.neezybackend.member.domain.Member;
+import com.likelion.neezybackend.member.domain.Role;
+import com.likelion.neezybackend.member.domain.repository.MemberRepository;
+import com.likelion.neezybackend.oauth.api.dto.Token;
+import com.likelion.neezybackend.oauth.api.dto.UserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AuthLoginService {
+
+//    // 컨트롤러에서 받은 authorization code와 소셜 로그인 id를 받아 콘솔에 출력
+//    public void socialLogin(String code, String registrationId){
+//        System.out.println("code = " + code);
+//        System.out.println("registrationId = " + registrationId);
+//    }
+
+    @Value("${client-id}") // import 시 lombok으로 하면 안됨
+    private String GOOGLE_CLIENT_ID;
+
+    @Value("${client-secret}")
+    private String GOOGLE_CLIENT_SECRET;
+
+    // 구글 인증 코드를 엑세스 토큰으로 교환하는 API 주소
+    private final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+    // OAuth 인증 후 구글이 리디렉션할 URI
+    private final String GOOGLE_REDIRECT_URI = "http://localhost:8080/login/oauth2/code/google";
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public String getGoogleAccessToken(String code) {
+        RestTemplate restTemplate = new RestTemplate();
+        Map<String, String> params = Map.of(
+                "code", code,
+                "scope", "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email",
+                "client_id", GOOGLE_CLIENT_ID,
+                "client_secret", GOOGLE_CLIENT_SECRET,
+                "redirect_uri", GOOGLE_REDIRECT_URI,
+                "grant_type", "authorization_code"
+        );
+
+        ResponseEntity<String> responseEntity = restTemplate.postForEntity(GOOGLE_TOKEN_URL, params, String.class);
+
+        if(responseEntity.getStatusCode().is2xxSuccessful()) {
+            String json = responseEntity.getBody();
+            Gson gson = new Gson();
+
+            return gson.fromJson(json, Token.class)
+                    .getAccessToken();
+        }
+        throw new RuntimeException("구글 엑세스 토큰을 가져오는데 실패했습니다.");
+    }
+
+    public Token loginOrSignUp(String googleAccessToken){
+        UserInfo userInfo = getUserInfo(googleAccessToken);
+
+        if(!userInfo.getVerifiedEmail()){
+            throw new RuntimeException("이메일 인증이 되지 않은 유저입니다.");
+        }
+
+        Member member = memberRepository.findByEmail(userInfo.getEmail()).orElseGet(() ->
+                memberRepository.save(
+                        Member.builder()
+                                .provider("google")                   // 필수
+                                .providerId(userInfo.getId())         // v2 userinfo는 id, OIDC면 sub
+                                .email(userInfo.getEmail())
+                                .name(userInfo.getName())
+                                .pictureUrl(userInfo.getPictureUrl())
+                                .role(Role.PENDING)                   // ROLE_USER 아님
+                                .build()
+                )
+        );
+
+        String jwt = jwtTokenProvider.generateToken(member);
+        return new Token(jwt);
+    }
+
+    // --- Kakao 설정 (클래스 멤버로 추가) ---
+    @Value("${kakao.client-id}")
+    private String KAKAO_CLIENT_ID;
+
+    @Value("${kakao.client-secret:}")
+    private String KAKAO_CLIENT_SECRET; // 시크릿 미사용이면 빈 문자열도 OK
+
+    @Value("${kakao.redirect-uri}")
+    private String KAKAO_REDIRECT_URI;
+
+    // 인가코드 -> 카카오 액세스 토큰 (폼 인코딩 필수)
+    public String getKakaoAccessToken(String code) {
+        String url = "https://kauth.kakao.com/oauth/token";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        org.springframework.util.MultiValueMap<String,String> body = new org.springframework.util.LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", KAKAO_CLIENT_ID);
+        body.add("redirect_uri", KAKAO_REDIRECT_URI);
+        body.add("code", code);
+        if (KAKAO_CLIENT_SECRET != null && !KAKAO_CLIENT_SECRET.isBlank()) {
+            body.add("client_secret", KAKAO_CLIENT_SECRET);
+        }
+
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> res =
+                rt.postForEntity(url, new HttpEntity<>(body, headers), String.class);
+
+        if (res.getStatusCode().is2xxSuccessful()) {
+            return new Gson().fromJson(res.getBody(), Token.class).getAccessToken();
+        }
+        throw new RuntimeException("카카오 액세스 토큰 발급 실패");
+    }
+
+    // 액세스 토큰 -> 카카오 유저 정보
+    public com.likelion.neezybackend.oauth.api.dto.KakaoUserInfo getKakaoUserInfo(String accessToken){
+        String url = "https://kapi.kakao.com/v2/user/me";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> res =
+                rt.exchange(url, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        if (res.getStatusCode().is2xxSuccessful()) {
+            return new Gson().fromJson(res.getBody(), com.likelion.neezybackend.oauth.api.dto.KakaoUserInfo.class);
+        }
+        throw new RuntimeException("카카오 사용자 정보 조회 실패");
+    }
+
+    // 회원 처리 + JWT 발급
+    public Token loginOrSignUpWithKakao(String accessToken){
+        var u = getKakaoUserInfo(accessToken);
+
+        String provider   = "kakao";
+        String providerId = String.valueOf(u.getId());
+        String email = (u.getKakaoAccount() != null) ? u.getKakaoAccount().getEmail() : null;
+        String name  = (u.getKakaoAccount() != null && u.getKakaoAccount().getProfile() != null)
+                ? u.getKakaoAccount().getProfile().getNickname() : null;
+        String pic   = (u.getKakaoAccount() != null && u.getKakaoAccount().getProfile() != null)
+                ? u.getKakaoAccount().getProfile().getProfileImageUrl() : null;
+
+        // 이메일은 동의 안 할 수 있으니 provider+providerId로 식별
+        Member member = memberRepository.findByProviderAndProviderId(provider, providerId)
+                .orElseGet(() -> memberRepository.save(
+                        Member.builder()
+                                .provider(provider).providerId(providerId)
+                                .email(email).name(name).pictureUrl(pic)
+                                .role(Role.PENDING)   // 역할 선택 전
+                                .build()
+                ));
+
+        String jwt = jwtTokenProvider.generateToken(member);
+        return new Token(jwt);
+    }
+
+
+    public UserInfo getUserInfo(String accessToken){
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "https://www.googleapis.com/oauth2/v2/userinfo?access_token=" + accessToken;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        RequestEntity<Void> requestEntity = new RequestEntity<>(headers, HttpMethod.GET, URI.create(url));
+        ResponseEntity<String> responseEntity = restTemplate.exchange(requestEntity, String.class);
+
+        if(responseEntity.getStatusCode().is2xxSuccessful()) {
+            String json = responseEntity.getBody();
+            Gson gson = new Gson();
+            return gson.fromJson(json, UserInfo.class);
+        }
+
+        throw new RuntimeException("유저 정보를 가져오는데 실패했습니다.");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,18 +2,43 @@ spring:
   profiles:
     active: prod
 
+
+  datasource:
+    url: ${spring.datasource.url}
+    username: ${spring.datasource.username}
+    password: ${spring.datasource.password}
+    driver-class-name: ${spring.datasource.driver-class-name}
+
   jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
       ddl-auto: update
     show-sql: true
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
-        format_sql: true
+        format_sql: false
+        use_sql_comments: true
         show_sql: true
-    open-in-view: false
+  open-in-view: false
 
 logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql: trace
+
+jwt:
+  secret: ${JWT_SECRET}   # 운영은 환경변수/시크릿에서 주입
+
+token:
+  expire:
+    time: ${JWT_ACCESS_TOKEN_VALIDITY_IN_MILLISECONDS:1800000}  # 없으면 기본 30분
+
+# 구글 (운영 환경변수에서 주입)
+client-id: ${GOOGLE_CLIENT_ID}
+client-secret: ${GOOGLE_CLIENT_SECRET}
+
+# 카카오 (운영 환경변수에서 주입 권장)
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  redirect-uri: http://localhost:8080/login/oauth2/code/kakao


### PR DESCRIPTION
무엇:
- API (컨트롤러: /api/members)
  - GET    /api/members/{memberId}         : 내 정보 조회
  - PATCH  /api/members/{memberId}         : 내 정보 부분 수정(name, email, age, gender, pictureUrl)
  - DELETE /api/members/{memberId}         : 내 계정 삭제
  - PATCH  /api/members/{memberId}/role    : PENDING → USER/FOUNDER 1회 선택
- 서비스 (MemberService)
- 도메인/레포지토리
  - Member 엔티티: age, gender 필드 및 update(dto), chooseRole(role) 도메인 메서드 추가
  - Role, Gender Enum 도입
- DTO (record)
  - MemberUpdateRequestDto, ChooseRoleRequestDto
  - MemberInfoResponseDto

왜:
- 소셜 로그인만으로는 프로필(이름/이메일/나이/성별)이 불완전 → 사용자가 마이페이지에서 직접 보완/수정할 수 있게 함
- 역할(role)은 앱 도메인 권한이므로 외부 OAuth와 분리, 온보딩에서 단 1회 확정하여 권한/흐름을 명확히 관리
- 경로를 /api/members/{memberId}로 통일해 프론트 연동 단순화

Closes #3 