### PR TITLE
[fix]: Token반환시 MemberId도 같이 반환 

### DIFF
--- a/src/main/java/com/likelion/neezybackend/oauth/api/dto/Token.java
+++ b/src/main/java/com/likelion/neezybackend/oauth/api/dto/Token.java
@@ -12,4 +12,7 @@ public class Token {
 
     @SerializedName("access_token")
     private String accessToken;
+
+    Long memberId;   // 추가
+
 }

--- a/src/main/java/com/likelion/neezybackend/oauth/application/AuthLoginService.java
+++ b/src/main/java/com/likelion/neezybackend/oauth/application/AuthLoginService.java
@@ -85,7 +85,7 @@ public class AuthLoginService {
         );
 
         String jwt = jwtTokenProvider.generateToken(member);
-        return new Token(jwt);
+        return new Token(jwt, member.getMemberId());
     }
 
     // --- Kakao 설정 (클래스 멤버로 추가) ---
@@ -165,7 +165,7 @@ public class AuthLoginService {
                 ));
 
         String jwt = jwtTokenProvider.generateToken(member);
-        return new Token(jwt);
+        return new Token(jwt, member.getMemberId());
     }
 
 

--- a/src/main/java/com/likelion/neezybackend/post/api/PostController.java
+++ b/src/main/java/com/likelion/neezybackend/post/api/PostController.java
@@ -22,11 +22,10 @@ import org.springframework.web.bind.annotation.*;
 public class PostController {
     private final PostService postService;
 
-
-    // 게시글 조회 (전체 최신순)
+    // 게시글 조회 (지역별 최신순)
     @Operation(
-            summary = "게시글 전체 조회",
-            description = "등록되어 있는 모든 게시글 정보를 최신순으로 조회한다",
+            summary = "지역별 게시글 조회",
+            description = "지역별로 게시글 정보를 최신순으로 조회한다",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
@@ -39,7 +38,34 @@ public class PostController {
                                           "posts": [
                                             {
                                               "postId": 1,
-
+                                              "writer": "김멋사",
+                                              "title": "이쁜 카페",
+                                              "contents": "분위기 있고 좋은 카페있으면 좋겠네요",
+                                              "region": "서울특별시 온수동",
+                                              "category": "CAFE",
+                                              "createdAt": "2025-08-18T12:00:00",
+                                              "updatedAt": "2025-08-18T12:10:00"
+                                            },
+                                            {
+                                              "postId": 2,
+                                              "writer": "김멋사",
+                                              "title": "PC방",
+                                              "contents": "동네에 PC방이 필요해요",
+                                              "region": "서울특별시 온수동",
+                                              "category": "PC_ROOM",
+                                              "createdAt": "2025-08-18T12:00:00",
+                                              "updatedAt": "2025-08-18T12:10:00"
+                                            }
+                                          ]
+                                        }
+                                    """)
+                            )
+                    )
+            }
+    )
+    @GetMapping("/region/{region}")
+    public ResponseEntity<PostListResponseDto> findAllByRegion(@PathVariable String region) {
+        PostListResponseDto body = postService.findAllByRegionLatest(region);
         return ResponseEntity.ok(body);
     }
 
@@ -56,6 +82,9 @@ public class PostController {
                             examples = @ExampleObject(value = """
                                 {
                                   "title": "새 글 제목",
+                                  "contents": "새 글 내용",
+                                  "region": "서울특별시 온수동",
+                                  "category": "BOWLING"
                                 }
                             """)
                     )
@@ -86,7 +115,8 @@ public class PostController {
                             examples = @ExampleObject(value = """
                                 {
                                   "title": "수정된 제목",
-
+                                  "contents": "수정된 내용",
+                                  "category": "PC_ROOM"
                                 }
                             """)
                     )

--- a/src/main/java/com/likelion/neezybackend/post/api/dto/request/PostSaveRequestDto.java
+++ b/src/main/java/com/likelion/neezybackend/post/api/dto/request/PostSaveRequestDto.java
@@ -7,6 +7,5 @@ public record PostSaveRequestDto(
         String contents,
         String region,     // 지역 (필수 입력)
         Category category
-
 ) {
 }

--- a/src/main/java/com/likelion/neezybackend/post/api/dto/request/PostUpdateRequestDto.java
+++ b/src/main/java/com/likelion/neezybackend/post/api/dto/request/PostUpdateRequestDto.java
@@ -6,6 +6,5 @@ public record PostUpdateRequestDto(
         String title,
         String contents,
         Category category
-
 ) {
 }

--- a/src/main/java/com/likelion/neezybackend/post/api/dto/response/PostInfoResponseDto.java
+++ b/src/main/java/com/likelion/neezybackend/post/api/dto/response/PostInfoResponseDto.java
@@ -1,6 +1,6 @@
 package com.likelion.neezybackend.post.api.dto.response;
 
-
+import com.likelion.neezybackend.post.domain.Category;
 import com.likelion.neezybackend.post.domain.Post;
 import lombok.Builder;
 
@@ -13,7 +13,8 @@ public record PostInfoResponseDto(
         String writer,
         String title,
         String contents,
-
+        String region,
+        Category category,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -24,6 +25,8 @@ public record PostInfoResponseDto(
                 .writer(post.getMember().getName())
                 .title(post.getTitle())
                 .contents(post.getContents())
+                .region(post.getRegion())
+                .category(post.getCategory())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();

--- a/src/main/java/com/likelion/neezybackend/post/application/PostService.java
+++ b/src/main/java/com/likelion/neezybackend/post/application/PostService.java
@@ -28,13 +28,20 @@ public class PostService {
         var post = Post.builder()
                 .title(dto.title())
                 .contents(dto.contents())
-
+                .region(dto.region())          // region 추가
+                .category(dto.category())      // category 추가
                 .member(member)
                 .build();
 
         postRepository.save(post);
     }
 
+    // 특정 지역 최신순 조회
+    public PostListResponseDto findAllByRegionLatest(String region) {
+        var posts = postRepository.findAllByRegionOrderByCreatedAtDesc(region);
+        var items = posts.stream()
+                .map(PostInfoResponseDto::from)
+                .toList();
         return PostListResponseDto.from(items);
     }
 

--- a/src/main/java/com/likelion/neezybackend/post/domain/Post.java
+++ b/src/main/java/com/likelion/neezybackend/post/domain/Post.java
@@ -26,6 +26,16 @@ public class Post {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String contents;
 
+    // 지역 필드 추가 (프론트에서 전달받아 저장)
+    @Column(nullable = false, length = 100)
+    private String region; // 예: "온수동", "강남구"
+
+    // 카테고리 필드 추가 (Enum)
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private Category category;
+
+
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
@@ -54,6 +64,17 @@ public class Post {
         if (postUpdateRequestDto.contents() != null && !postUpdateRequestDto.contents().isBlank()) {
             this.contents = postUpdateRequestDto.contents();
         }
+        if (postUpdateRequestDto.category() != null) {
+            this.category = postUpdateRequestDto.category();
+        }
+    }
+
+    @Builder
+    private Post(String title, String contents, String region, Category category, Member member) {
+        this.title = title;
+        this.contents = contents;
+        this.region = region;
+        this.category = category;
         this.member = member;
     }
 }

--- a/src/main/java/com/likelion/neezybackend/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/likelion/neezybackend/post/domain/repository/PostRepository.java
@@ -4,7 +4,6 @@ import com.likelion.neezybackend.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;
 
-
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {


### PR DESCRIPTION

Token반환시 MemberId도 같이 반환하게 수정

### 🌳 이슈 번호
--- #16 

close #16 

### ☀️ 어떻게 이슈를 해결했나요?

--- Google / Kakao 로그인 성공 시 응답 객체(Token)에 memberId 추가

--- AuthLoginService에서 JWT 발급 후 memberId 포함 반환하도록 수정


- <!-- 실제로 해결한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->
- 

### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
